### PR TITLE
Fix README example typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ function App() {
     <BlockForgeEditor
       data={initialData}
       onChange={handleChange}
-      onSave={handeSave}
+      onSave={handleSave}
       onCancel={handleCancel}
       tools={[...array of your editor js tools]}
     />


### PR DESCRIPTION
## Summary
- fix a typo in the README component example

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: dependency conflict)*

------
https://chatgpt.com/codex/tasks/task_e_684000f86fb4832f9a69730a10539624